### PR TITLE
Fix META

### DIFF
--- a/META.info
+++ b/META.info
@@ -3,9 +3,7 @@
     "version"     : "0.1",
     "description" : "Display and cache ecosystem README files for perl6",
     "depends"     : ["Net::Curl","Panda","IO::Capture::Simple"],
-    "provides"    : {
-            "App::ecoreadme": "bin/ecoreadme"
-    },
-    "source-url"  : " git@github.com:stmuk/p6-eco-readme.git",
+    "provides"    : {},
+    "source-url"  : "git://github.com/stmuk/p6-eco-readme.git",
     "author"      : "Steve Mynott <steve.mynott@gmail.com>"
 }


### PR DESCRIPTION
This fixes the problem with your module not being included on modules.perl6.org (https://github.com/perl6/modules.perl6.org/issues/11)

Also, the `provides` field is only for things that the user could `use`. You don't list binaries in there.
